### PR TITLE
Improve lesson quality via adaptive prompts and optional exercises

### DIFF
--- a/backend/src/routes/lesson.test.ts
+++ b/backend/src/routes/lesson.test.ts
@@ -17,6 +17,7 @@ const mockLesson = {
   explanation: 'createSlice combines action creators and reducers.',
   knownWayCode: 'const reducer = (state, action) => { ... }',
   targetWayCode: 'const slice = createSlice({ name, initialState, reducers })',
+  hasExercise: true,
   exercise: 'Convert this Redux reducer to use createSlice.',
   starterCode: 'const counterReducer = (state = 0, action) => { ... }',
   solutionCode: 'const counterSlice = createSlice({ ... })',
@@ -152,6 +153,19 @@ describe('POST /api/lesson/generate', () => {
     expect(generateLesson).not.toHaveBeenCalled()
   })
 
+  it('normalizes legacy cached lessons missing hasExercise by defaulting it to true', async () => {
+    const legacyLesson = { ...mockLesson }
+    delete (legacyLesson as Record<string, unknown>)['hasExercise']
+    saveLesson('legacy-course', 'legacy-lesson', legacyLesson)
+
+    const res = await request(app)
+      .post('/api/lesson/generate')
+      .send({ ...validBody, courseId: 'legacy-course', lessonId: 'legacy-lesson' })
+
+    expect(res.status).toBe(200)
+    expect(res.body.hasExercise).toBe(true)
+  })
+
   it('route returns early on a cache hit — the existing DB row is not re-written', async () => {
     // Seed the cache and record the timestamp to verify the route never calls saveLesson
     saveLesson('no-overwrite-course', 'no-overwrite-lesson', mockLesson)
@@ -256,6 +270,29 @@ describe('POST /api/lesson/generate', () => {
 
     expect(res.status).toBe(500)
     expect(res.body.error).toBe('Failed to generate lesson')
+  })
+
+  it('returns 500 when generateLesson resolves to null (malformed model response)', async () => {
+    vi.mocked(generateLesson).mockResolvedValue(null as unknown as ReturnType<typeof generateLesson> extends Promise<infer T> ? T : never)
+    const body = {
+      ...validBody,
+      courseId: `null-course-${Date.now()}`,
+      lessonId: `null-lesson-${Date.now()}`,
+    }
+
+    const res = await request(app).post('/api/lesson/generate').send(body)
+
+    expect(res.status).toBe(500)
+    expect(res.body.error).toBe('Failed to generate lesson')
+  })
+
+  it('returns 400 when courseId is a non-string type', async () => {
+    const res = await request(app)
+      .post('/api/lesson/generate')
+      .send({ ...validBody, courseId: 42 })
+
+    expect(res.status).toBe(400)
+    expect(res.body).toHaveProperty('error')
   })
 
   it('400 response body contains a structured zod error with fieldErrors', async () => {

--- a/backend/src/routes/lesson.test.ts
+++ b/backend/src/routes/lesson.test.ts
@@ -273,7 +273,9 @@ describe('POST /api/lesson/generate', () => {
   })
 
   it('returns 500 when generateLesson resolves to null (malformed model response)', async () => {
-    vi.mocked(generateLesson).mockResolvedValue(null as unknown as ReturnType<typeof generateLesson> extends Promise<infer T> ? T : never)
+    vi.mocked(generateLesson).mockResolvedValue(
+      null as unknown as ReturnType<typeof generateLesson> extends Promise<infer T> ? T : never
+    )
     const body = {
       ...validBody,
       courseId: `null-course-${Date.now()}`,

--- a/backend/src/routes/lesson.ts
+++ b/backend/src/routes/lesson.ts
@@ -25,11 +25,21 @@ router.post('/generate', async (req, res) => {
   try {
     const cached = getLesson(courseId, lessonId)
     if (cached) {
-      res.json(cached)
+      // Clone before mutating to avoid corrupting the object returned by the DB layer
+      const lesson = { ...(cached as Record<string, unknown>) }
+      // Normalize legacy cached lessons that predate the hasExercise field
+      if (lesson['hasExercise'] === undefined) {
+        lesson['hasExercise'] = true
+      }
+      res.json(lesson)
       return
     }
 
     const lesson = await generateLesson(knownTech, targetTech, lessonTitle)
+    if (!lesson) {
+      res.status(500).json({ error: 'Failed to generate lesson' })
+      return
+    }
     saveLesson(courseId, lessonId, lesson)
     res.json(lesson)
   } catch (err) {

--- a/backend/src/services/anthropic.ts
+++ b/backend/src/services/anthropic.ts
@@ -30,12 +30,13 @@ const CURRICULUM_SCHEMA = `{
 const LESSON_SCHEMA = (knownTech: string, targetTech: string) => `{
   "id": "string (uuid)",
   "title": "string",
-  "explanation": "string (markdown, 2-4 paragraphs explaining the concept and how it maps from ${knownTech} to ${targetTech})",
+  "explanation": "string (markdown; length should match concept complexity — one tight paragraph for simple concepts, up to 4 paragraphs for nuanced ones; always map from ${knownTech} to ${targetTech})",
   "knownWayCode": "string (code example showing the ${knownTech} approach)",
   "targetWayCode": "string (code example showing the ${targetTech} approach)",
-  "exercise": "string (markdown, a hands-on exercise prompt)",
-  "starterCode": "string (starter code for the exercise)",
-  "solutionCode": "string (complete solution)",
+  "hasExercise": "boolean (true if a meaningful hands-on exercise is included; false if the concept is too simple, too abstract, or the exercise would just repeat the code comparison above)",
+  "exercise": "string (markdown hands-on exercise prompt, or empty string if hasExercise is false)",
+  "starterCode": "string (starter code for the exercise, or empty string if hasExercise is false)",
+  "solutionCode": "string (complete solution, or empty string if hasExercise is false)",
   "language": "string (typescript | javascript | python)"
 }`
 
@@ -65,7 +66,14 @@ export async function generateCurriculum(
           },
           {
             type: 'text',
-            text: `Generate a curriculum teaching ${targetTech} to someone who already knows ${knownTech}. Include 4-6 modules, each with 3-5 lessons.`,
+            text: `Generate a curriculum teaching ${targetTech} to someone who already knows ${knownTech}.
+
+Structure the curriculum based on the complexity of the topic:
+- Simple migrations or incremental upgrades: 2-3 modules, 2-4 lessons each
+- Moderate topics: 3-5 modules, 3-5 lessons each
+- Complex new paradigms: 4-6 modules, 4-6 lessons each
+
+Use your judgment — don't pad with unnecessary modules or lessons if the topic doesn't warrant them.`,
           },
         ],
       },
@@ -104,7 +112,14 @@ export async function generateLesson(
           },
           {
             type: 'text',
-            text: `Generate full lesson content for: "${lessonTitle}" in a course teaching ${targetTech} to someone who knows ${knownTech}.`,
+            text: `Generate full lesson content for: "${lessonTitle}" in a course teaching ${targetTech} to someone who knows ${knownTech}.
+
+For the exercise: include one if there's a meaningful hands-on task the learner can complete independently. A good exercise asks the learner to write new code or adapt a pattern — not just copy the example above.
+
+Skip the exercise (set hasExercise to false, leave exercise/starterCode/solutionCode as empty strings) if:
+- The concept is purely conceptual or philosophical (e.g. "why X exists")
+- The exercise would be trivially obvious (e.g. "change the variable name")
+- It would just repeat the code comparison with no added learning value`,
           },
         ],
       },

--- a/backend/src/types.ts
+++ b/backend/src/types.ts
@@ -32,6 +32,7 @@ export interface Lesson {
   explanation: string
   knownWayCode: string
   targetWayCode: string
+  hasExercise: boolean
   exercise: string
   starterCode: string
   solutionCode: string

--- a/frontend/src/components/LessonView.tsx
+++ b/frontend/src/components/LessonView.tsx
@@ -159,22 +159,24 @@ export function LessonView({ lesson, knownTech, targetTech, isCompleted, onMarkC
         )}
 
         {/* Exercise */}
-        <section style={{ marginBottom: 20 }}>
-          <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 12 }}>Exercise</h2>
-          <div
-            style={{
-              padding: '12px 16px',
-              background: '#f9fafb',
-              borderRadius: 8,
-              marginBottom: 16,
-              fontSize: 14,
-              lineHeight: 1.6,
-            }}
-          >
-            <ReactMarkdown>{lesson.exercise}</ReactMarkdown>
-          </div>
-          <CodeEditor lesson={lesson} />
-        </section>
+        {lesson.hasExercise && (
+          <section style={{ marginBottom: 20 }}>
+            <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 12 }}>Exercise</h2>
+            <div
+              style={{
+                padding: '12px 16px',
+                background: '#f9fafb',
+                borderRadius: 8,
+                marginBottom: 16,
+                fontSize: 14,
+                lineHeight: 1.6,
+              }}
+            >
+              <ReactMarkdown>{lesson.exercise}</ReactMarkdown>
+            </div>
+            <CodeEditor lesson={lesson} />
+          </section>
+        )}
       </div>
     </div>
   )

--- a/frontend/src/components/__tests__/LessonView.test.tsx
+++ b/frontend/src/components/__tests__/LessonView.test.tsx
@@ -32,6 +32,7 @@ const lesson: Lesson = {
   id: 'l1',
   title: 'createSlice basics',
   explanation: 'Use **createSlice** to reduce boilerplate.',
+  hasExercise: true,
   exercise: 'Write a counter slice.',
   knownWayCode: 'const reducer = (state, action) => state',
   targetWayCode: 'const slice = createSlice({...})',
@@ -66,6 +67,19 @@ describe('LessonView', () => {
   it('renders the exercise prompt', () => {
     renderLesson()
     expect(screen.getByText('Write a counter slice.')).toBeInTheDocument()
+  })
+
+  it('hides the exercise section when hasExercise is false', () => {
+    const noExerciseLesson: Lesson = {
+      ...lesson,
+      hasExercise: false,
+      exercise: '',
+      starterCode: '',
+      solutionCode: '',
+    }
+    renderLesson({ lesson: noExerciseLesson })
+    expect(screen.queryByRole('heading', { name: 'Exercise' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument()
   })
 
   it('shows "Mark Complete" when the lesson is not completed', () => {
@@ -141,6 +155,14 @@ describe('LessonView', () => {
     renderLesson()
     await user.click(screen.getByRole('button', { name: 'Sequential' }))
     expect(screen.queryByRole('button', { name: /Scroll/ })).not.toBeInTheDocument()
+  })
+
+  it('hides the scroll-synced panels in sequential mode', async () => {
+    const user = userEvent.setup()
+    renderLesson()
+    await user.click(screen.getByRole('button', { name: 'Sequential' }))
+    expect(screen.queryByTestId('left-scroll-panel')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('right-scroll-panel')).not.toBeInTheDocument()
   })
 
   it('unlocks scroll when clicking the locked button', async () => {

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -23,6 +23,7 @@ export interface Lesson {
   explanation: string
   knownWayCode: string
   targetWayCode: string
+  hasExercise: boolean
   exercise: string
   starterCode: string
   solutionCode: string


### PR DESCRIPTION
## Summary

- Add `hasExercise: boolean` to `Lesson` type (backend + frontend) so the model's intent is explicit and the UI can gate on it
- Curriculum prompt now scales module/lesson count to topic complexity instead of always requiring 4-6 modules × 3-5 lessons
- Lesson explanation length is complexity-aware (one tight paragraph → up to 4) instead of a fixed 2-4 paragraph requirement
- Exercise is optional: model is instructed to skip for purely conceptual or trivially obvious lessons
- `LessonView` hides the exercise section (heading + editor) when `hasExercise` is false
- `lesson.ts` normalizes legacy cached lessons missing `hasExercise` → defaults to `true` (backward-compatible)
- Guard against `null` return from `generateLesson` (returns 500 instead of saving/serving a null lesson)

## Test plan

- [ ] Backend: `cd backend && npm test` — 156 tests pass
- [ ] Frontend: `cd frontend && npm test` — 85 tests pass
- [ ] Both: `npm run lint` clean
- [ ] New lesson for a simple topic (e.g. Redux → Redux Toolkit) should produce fewer modules/lessons than a complex one (e.g. Python → Go)
- [ ] Conceptual lessons should have `hasExercise: false` and the exercise section should be hidden
- [ ] Existing cached lessons (without `hasExercise`) should still show their exercise section

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)